### PR TITLE
[ADD] 회원가입 시, 이메일 중복 처리

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -30,7 +30,15 @@ export class AuthController {
         @Body(ValidationPipe) authcredentialsDto: AuthCredentialsDto
     ): Promise<any> {
         try{
-            const { nickname } = authcredentialsDto;
+            const { email, nickname } = authcredentialsDto;
+            const emailUser = await this.authService.findByAuthEmail(email);
+            if(emailUser)
+                return res.
+                    status(HttpStatus.CONFLICT)
+                    .json({
+                        success: false,
+                        message: '중복된 이메일이 있습니다.'
+                    })
             const nicknameUser = await this.authService.findByAuthNickname(nickname);
             if(nicknameUser)
                 return res.

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -1,8 +1,9 @@
-import { EntityRepository, Repository } from "typeorm";
+import { EntityRepository, FindRelationsNotFoundError, Repository } from "typeorm";
 import { Users } from "src/users/users.entity";
 import { UpdateProfileDto } from "./dto/update-profile.dto";
 import { PasswordDto } from "./dto/password.dto";
 import * as bcrypt from "bcryptjs";
+import { empty } from "rxjs";
 
 @EntityRepository(Users)
 export class UsersRepository extends Repository<Users> {
@@ -48,7 +49,14 @@ export class UsersRepository extends Repository<Users> {
     }
 
     async deleteUser(userId: number){
-        await this.update({userId}, {userStatus: false});
+        
+        const user = await this.findOne(userId);
+        user.userStatus = false;
+        user.email = null;
+        
+        await this.save(user);
+        
+        // await this.update({userId}, {userStatus: false});
     }
 
     // 작성한 글 가져오기 _ 카테고리명, 제목, 닉네임, 내용, n시간전, 이미지 개수


### PR DESCRIPTION
탈퇴시, 이메일 데이터가 남아있으면 인덱싱에 걸려서 (unique값) 탈퇴한 유저의 경우 이메일 칼럼을 null값으로 처리했습니다!